### PR TITLE
Переделал helpers без GuardedActionType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindbox/redux-helpers",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "Typed factories for your redux reducers and actions.",
     "keywords": [
         "typescript",


### PR DESCRIPTION
Раньше компилятор ругался на:
```typescript
class GuardedActionType<TPayload> {		
	private _type: string;		
			
	constructor(type: string) {		
		this._type = type;		
	}		
		
	public toString() {		
		return this._type;		
	}		
}
```
говоря, что `TPayload` не нужен. Он и правда не используется, так что я решил переписать всё без GuardedActionType. Потестил в directcrm - всё ок. Может вы видите подводные камни?

Кстати, @TheHatSky перед выкладкой в npm не забудь сбилдить js-код. Сейчас у версии 1.0.9 тайпинги новые, а js еще без `createPrimitiveReducer`.